### PR TITLE
Add diff colors

### DIFF
--- a/Lucario.tmTheme
+++ b/Lucario.tmTheme
@@ -304,6 +304,56 @@
 				<string>#F8F8F0</string>
 			</dict>
 		</dict>
+        <dict>
+            <key>name</key>
+            <string>diff.header</string>
+            <key>scope</key>
+            <string>meta.diff, meta.diff.header</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#75715E</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>diff.deleted</string>
+            <key>scope</key>
+            <string>markup.deleted</string>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#2b3e50</string>
+                <key>foreground</key>
+                <string>#F92672</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>diff.inserted</string>
+            <key>scope</key>
+            <string>markup.inserted</string>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#2b3e50</string>
+                <key>foreground</key>
+                <string>#A6E22E</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>diff.changed</string>
+            <key>scope</key>
+            <string>markup.changed</string>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#2b3e50</string>
+                <key>foreground</key>
+                <string>#E6DB74</string>
+            </dict>
+        </dict>
 	</array>
 	<key>uuid</key>
 	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>


### PR DESCRIPTION
I don't know if you're interested but the commit adds some color when using a diff with Sublime Text (for example, using [SublimeGit](https://sublimegit.net/))

Before:
![from](https://cloud.githubusercontent.com/assets/692077/3406474/dc1bb3f0-fd8f-11e3-918b-b06b0d7fb1a6.png)

After:
![to](https://cloud.githubusercontent.com/assets/692077/3406475/e65b459c-fd8f-11e3-8f40-820720b9126b.png)

Great theme!
