### PR TITLE
Improvements to vim cterm colors (Refs: #10)

### DIFF
--- a/vim/lucario.vim
+++ b/vim/lucario.vim
@@ -1,4 +1,4 @@
-" Lucario - The best colorful flat theme ever 
+" Lucario - The best colorful flat theme ever
 " Author: Raphael Amorim
 "
 " GitHub project: https://github.com/raphamorim/lucario
@@ -12,12 +12,12 @@ endif
 
 let g:colors_name = "lucario"
 
-hi Cursor guibg=yellow cterm=NONE guifg=#2b3e50 guibg=#f8f8f2
+hi Cursor cterm=NONE guifg=#2b3e50 guibg=#f8f8f2
 hi Visual ctermfg=NONE ctermbg=16 cterm=NONE guifg=NONE guibg=#19242f gui=NONE
-hi CursorLine ctermfg=NONE ctermbg=25 cterm=NONE guifg=NONE guibg=#405160 gui=NONE
-hi CursorColumn ctermfg=231 ctermbg=25 cterm=NONE guifg=NONE guibg=#405160 gui=NONE
+hi CursorLine ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#405160 gui=NONE
+hi CursorColumn ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#405160 gui=NONE
 hi ColorColumn ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#405160 gui=NONE
-hi LineNr ctermfg=231 ctermbg=240 cterm=NONE guifg=#929ba1 guibg=#405160 gui=NONE
+hi LineNr ctermfg=248 ctermbg=240 cterm=NONE guifg=#929ba1 guibg=#405160 gui=NONE
 hi VertSplit ctermfg=60 ctermbg=60 cterm=NONE guifg=#66747f guibg=#66747f gui=NONE
 hi MatchParen ctermfg=203 ctermbg=NONE cterm=underline guifg=#ff6541 guibg=NONE gui=underline
 hi StatusLine ctermfg=231 ctermbg=60 cterm=bold guifg=#f8f8f2 guibg=#66747f gui=bold
@@ -29,10 +29,15 @@ hi Search ctermfg=NONE ctermbg=NONE cterm=underline guifg=NONE guibg=NONE gui=un
 hi Directory ctermfg=177 ctermbg=NONE cterm=NONE guifg=#ca94ff guibg=NONE gui=NONE
 hi Folded ctermfg=68 ctermbg=23 cterm=NONE guifg=#5c98cd guibg=#2b3e50 gui=NONE
 
-hi Normal ctermfg=231 ctermbg=24 cterm=NONE guifg=#f8f8f2 guibg=#2b3e50 gui=NONE
+" Colors for tabs in cterm
+hi TabLineFill ctermfg=249
+hi TabLine ctermfg=17 ctermbg=249 cterm=NONE
+hi TabLineSel ctermfg=44 ctermbg=240 cterm=NONE
+
+hi Normal ctermfg=231 ctermbg=0 cterm=NONE guifg=#f8f8f2 guibg=#2b3e50 gui=NONE
 hi Boolean ctermfg=177 ctermbg=NONE cterm=NONE guifg=#ca94ff guibg=NONE gui=NONE
 hi Character ctermfg=177 ctermbg=NONE cterm=NONE guifg=#ca94ff guibg=NONE gui=NONE
-hi Comment ctermfg=33 ctermbg=NONE cterm=NONE guifg=#5c98cd guibg=NONE gui=NONE
+hi Comment ctermfg=44 ctermbg=NONE cterm=NONE guifg=#5c98cd guibg=NONE gui=NONE
 hi Conditional ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ff6541 guibg=NONE gui=NONE
 hi Constant ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
 hi Define ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ff6541 guibg=NONE gui=NONE
@@ -47,7 +52,7 @@ hi Function ctermfg=71 ctermbg=NONE cterm=NONE guifg=#72c05d guibg=NONE gui=NONE
 hi Identifier ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
 hi Keyword ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ff6541 guibg=NONE gui=NONE
 hi Label ctermfg=186 ctermbg=NONE cterm=NONE guifg=#e6db74 guibg=NONE gui=NONE
-hi NonText ctermfg=74 ctermbg=59 cterm=NONE guifg=#61bbc8 guibg=#354758 gui=NONE
+hi NonText ctermfg=74 ctermbg=0 cterm=NONE guifg=#61bbc8 guibg=#354758 gui=NONE
 hi Number ctermfg=177 ctermbg=NONE cterm=NONE guifg=#ca94ff guibg=NONE gui=NONE
 hi Operator ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ff6541 guibg=NONE gui=NONE
 hi PreProc ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ff6541 guibg=NONE gui=NONE
@@ -68,7 +73,7 @@ hi rubySymbol ctermfg=177 ctermbg=NONE cterm=NONE guifg=#ca94ff guibg=NONE gui=N
 hi rubyConstant ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
 hi rubyStringDelimiter ctermfg=186 ctermbg=NONE cterm=NONE guifg=#e6db74 guibg=NONE gui=NONE
 hi rubyBlockParameter ctermfg=214 ctermbg=NONE cterm=NONE guifg=#ffab28 guibg=NONE gui=italic
-hi rubyInstanceVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+hi rubyInstanceVariable ctermfg=81 ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
 hi rubyInclude ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ff6541 guibg=NONE gui=NONE
 hi rubyGlobalVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
 hi rubyRegexp ctermfg=186 ctermbg=NONE cterm=NONE guifg=#e6db74 guibg=NONE gui=NONE


### PR DESCRIPTION
This should improve term colors a bit. Not quite sure about `TabLineSel` - that one seems a bit out of place but it was the best I could do for now. Feel free to change it to something better :-)
