### PR TITLE
Macvim

### DIFF
--- a/vim/colors/lucario.vim
+++ b/vim/colors/lucario.vim
@@ -58,6 +58,7 @@ hi NonText ctermfg=74 ctermbg=0 cterm=NONE guifg=#61bbc8 guibg=#354758 gui=NONE
 hi Number ctermfg=177 ctermbg=NONE cterm=NONE guifg=#ca94ff guibg=NONE gui=NONE
 hi Operator ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ff6541 guibg=NONE gui=NONE
 hi PreProc ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ff6541 guibg=NONE gui=NONE
+hi Parameter ctermfg=214 ctermbg=NONE cterm=NONE guifg=#ffab28 guibg=NONE gui=italic
 hi Special ctermfg=231 ctermbg=NONE cterm=NONE guifg=#f8f8f2 guibg=NONE gui=NONE
 hi SpecialKey ctermfg=74 ctermbg=59 cterm=NONE guifg=#61bbc8 guibg=#405160 gui=NONE
 hi Statement ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ff6541 guibg=NONE gui=NONE


### PR DESCRIPTION
I changed the line number/gutter background colour to match the style from the screenshots.

The background colour for Pmenu was the same colour as the normal background colour, which was difficult to make out. I changed the background colour to the foreground, and selected a lighter colour from the theme as the foreground.

I added a generic Parameter definition since the only other ones I saw were rubyBlockParameter and cssURL. This way, people will be able to set the HiLink colour to Parameter in their vim syntax files.

Before
![before](https://cloud.githubusercontent.com/assets/828125/4469985/98b2ac76-491c-11e4-9e1a-6e8c0b396d1f.png)

After
![after](https://cloud.githubusercontent.com/assets/828125/4470008/134b573a-491d-11e4-9c47-cc1e717e868d.png)
