### PR TITLE
Padding in selection causes problems

### DIFF
--- a/index.less
+++ b/index.less
@@ -15,7 +15,6 @@
 
 .editor.is-focused .selection .region {
   background-color: #19242f;
-  padding: 6px;
 }
 
 .editor .gutter .line-number.git-line-added {


### PR DESCRIPTION
The padding used for selected text made the selection region go out and over the actual character selection. Expanding it down to the line below it and running it into characters to the right of it.