### PR TITLE
Fix indent-guide typo

### DIFF
--- a/atom/editor.less
+++ b/atom/editor.less
@@ -23,7 +23,7 @@ atom-text-editor,
     }
   }
 
-  .ident-guide{
+  .indent-guide{
     box-shadow: 1px 0 #444;
   }
 


### PR DESCRIPTION
This pull request fixes a small typo in `editor.less` that caused the indent guide to inherit the color of its nearest-neighboring text. 

This has been tested on linux and it seems to fix the issue.

Cheers :beers: 