### PR TITLE
Fix documentation for applying lucario in Termux

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ The script was created with [terminal.sexy](https://terminal.sexy).
 
 1.  Make sure that **Termux:Styling** add-on is installed.
 2.  Download **[termux/lucario.colors](https://github.com/raphamorim/lucario/raw/master/termux/lucario.colors)**
-3. Move the `lucario.colors` file to`~/.termux/colors`.
-2. Run the `colors.sh` script to apply.
+3. Replace the `lucario.colors` with `~/.termux/colors.properties`.
+4. Rename  `lucario.colors` to `colors.properties`.
+5. Restart **Termux** to apply.
 
 ## Xfce Terminal
 ![xfce4-terminal Example](https://raw.githubusercontent.com/raphamorim/lucario/master/images/xfce4-terminal.png)


### PR DESCRIPTION
The old documentation stated wrong steps to apply the **lucario** color scheme to **Termux**. To apply the scheme, with the **Termux:Styling** add-on installed, we just needed to replace the `~/colors.properties` file with the required color scheme.

There was no need of any `colors.sh` script. That script was part of the **oh-my-zsh** plugin, which in our case is unnecessary due to the Styling plugin provided by Termux.