### PR TITLE
Fix markdown typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ So how about creating one? It's very simple! \o/
 
 1.  Fork it!
 2.  Create your feature branch: `git checkout -b my-new-feature`
-3.  Commit your changes: `git commit -m 'Add some feature'``
+3.  Commit your changes: `git commit -m 'Add some feature'`
 4.  Push to the branch: `git push origin my-new-feature`
 5.  Submit a pull request :)
 


### PR DESCRIPTION
The 3rd step in Contributing section had an extra tick (`) which prevented monospaced font in the git command. Now, it renders correctly.